### PR TITLE
Refactored CMSIS-NN kernel additions as an example

### DIFF
--- a/tensorflow/lite/experimental/micro/README.md
+++ b/tensorflow/lite/experimental/micro/README.md
@@ -382,7 +382,7 @@ optimizations and link it with the microlite lib.
 To utilize the CMSIS-NN optimized kernels, choose your target, e.g. Bluepill,
 and build with:
 
-make -f tensorflow/lite/experimental/micro/tools/make/Makefile KERNEL_LIB=cmsis TARGET=bluepill test
+make -f tensorflow/lite/experimental/micro/tools/make/Makefile TAGS=cmsis-nn TARGET=bluepill test
 
 That will build a CMSIS library based on the version downloaded by
 'download_dependencies.sh', so make sure you have run this script. If you want to

--- a/tensorflow/lite/experimental/micro/tools/make/Makefile
+++ b/tensorflow/lite/experimental/micro/tools/make/Makefile
@@ -204,9 +204,9 @@ $(OBJDIR)%.o: %.S
 	$(CC) $(CCFLAGS) $(INCLUDES) -c $< -o $@
 
 # The target that's compiled if there's no command-line arguments.
-all: $(KERNEL_LIBS_PATH) $(MICROLITE_LIB_PATH)
+all: $(MICROLITE_LIB_PATH)
 
-microlite: $(KERNEL_LIBS_PATH) $(MICROLITE_LIB_PATH)
+microlite: $(MICROLITE_LIB_PATH)
 
 # Hack for generating schema file bypassing flatbuffer parsing
 tensorflow/lite/schema/schema_generated.h:
@@ -217,11 +217,11 @@ $(MICROLITE_LIB_PATH): tensorflow/lite/schema/schema_generated.h $(MICROLITE_LIB
 	@mkdir -p $(dir $@)
 	$(AR) $(ARFLAGS) $(MICROLITE_LIB_PATH) $(MICROLITE_LIB_OBJS)
 
-$(BINDIR)%_test : $(OBJDIR)%_test.o $(KERNEL_LIBS_PATH) $(MICROLITE_LIB_PATH)
+$(BINDIR)%_test : $(OBJDIR)%_test.o $(MICROLITE_LIB_PATH)
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) \
 	-o $@ $< \
-	$(LIBFLAGS) $(KERNEL_LIBS_PATH) $(MICROLITE_LIB_PATH) $(LDFLAGS) $(MICROLITE_LIBS)
+	$(LIBFLAGS) $(MICROLITE_LIB_PATH) $(LDFLAGS) $(MICROLITE_LIBS)
 
 $(BINDIR)%.test_target: $(BINDIR)%_test
 	$(TEST_SCRIPT) $< '~~~ALL TESTS PASSED~~~'

--- a/tensorflow/lite/experimental/micro/tools/make/ext_libs/cmsis.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/ext_libs/cmsis.inc
@@ -1,70 +1,15 @@
-ifeq ($(KERNEL_LIB), cmsis)
-  KERNEL_ROOT := tensorflow/lite/experimental/micro/kernels
-
-  # Below are example of how the depthwise_conv kernel is replaced with an
-  # architecture.
-  ifneq (,$(filter $(TARGET_ARCH), cortex-m0 cortex-m1))
-    # Let's say the depthwise_conv isn't implemented for this architecture =>
-    # reference kernel will be used
-  else ifneq (,$(filter $(TARGET_ARCH), cortex-m3 cortex-m4 cortex-m7))
+ifneq (,$(filter $(TARGET_ARCH), cortex-m3 cortex-m4 cortex-m7))
     # Let's say the depthwise_conv is implemented for this architecture =>
     # overrride the reference kernel
     CXXFLAGS += -DARM_MATH_CM4
     CCFLAGS += -DARM_MATH_CM4
-    REPLACE_KERNELS := $(KERNEL_ROOT)/depthwise_conv.cc
-    KERNELS_OPTIMIZED := $(KERNEL_ROOT)/cmsis-nn/depthwise_conv.cc
-  else ifneq (,$(filter $(TARGET_ARCH), cortex-m23 cortex-m33))
-    # Add more optimized kernels like this:
-    REPLACE_KERNELS := $(KERNEL_ROOT)/depthwise_conv.cc
-    REPLACE_KERNELS += $(KERNEL_ROOT)/softmax.cc
-    KERNELS_OPTIMIZED := $(KERNEL_ROOT)/cmsis-nn/depthwise_conv.cc
-    KERNELS_OPTIMIZED += $(KERNEL_ROOT)/cmsis-nn/softmax.cc
-  else
-    # x86_64 etc. only used for testing purposes
-    REPLACE_KERNELS := $(KERNEL_ROOT)/depthwise_conv.cc
-    KERNELS_OPTIMIZED := $(KERNEL_ROOT)/cmsis-nn/depthwise_conv.cc
-  endif
+endif
 
-  # Check if optimized kernals exist
-  ifneq ($(KERNELS_OPTIMIZED),)
-    # Check that dependency variables are defined
-    ifeq ($(MICROLITE_CC_SRCS),)
-      $(info Source files missing, MICROLITE_CC_SRCS: $(MICROLITE_CC_SRCS))
-    endif
-    ifeq ($(MAKEFILE_DIR),)
-      $(info Makefile path not defined, MAKEFILE_DIR: $(MAKEFILE_DIR))
-    endif
-    ifeq ($(LIBDIR),)
-      $(info Lib path not defined, LIBDIR: $(LIBDIR))
-    endif
-    ifeq ($(OBJDIR),)
-      $(info Obj path not defined, OBJDIR: $(OBJDIR))
-    endif
-
-    $(info CMSIS-NN target architecture: $(TARGET_ARCH))
-    $(info CMSIS-NN optimized kernels: $(KERNELS_OPTIMIZED))
-
-    # Replace ref kernel with CMSIS optimized kernel
-    MICROLITE_CC_SRCS := $(filter-out $(REPLACE_KERNELS), $(MICROLITE_CC_SRCS))
-    MICROLITE_CC_SRCS += $(KERNELS_OPTIMIZED)
-    $(foreach var, $(MICROLITE_CC_SRCS),$(info $(var)))
-
+ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
     # Setup CMSIS-NN lib and add required header files to microlite lib INCLUDE
     KERNEL_LIB_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
-    KERNEL_LIB_NAME := lib-cmsis.a
-    SOURCE_CMSIS := $(shell find $(KERNEL_LIB_PATH)/CMSIS/NN/Source/ -name *.c)
+    MICROLITE_CC_SRCS += $(shell find $(KERNEL_LIB_PATH)/CMSIS/NN/Source/ -name *.c)
     INCLUDES += -I$(KERNEL_LIB_PATH)/CMSIS/Core/Include \
                 -I$(KERNEL_LIB_PATH)/CMSIS/NN/Include \
                 -I$(KERNEL_LIB_PATH)/CMSIS/DSP/Include
-    KERNEL_LIBS_PATH += $(LIBDIR)$(KERNEL_LIB_NAME)
-    KERNEL_LIB_OBJS := $(addprefix $(OBJDIR), $(patsubst %.c,%.o,$(SOURCE_CMSIS)))
-
-# Recipe for the CMSIS-NN lib
-$(KERNEL_LIBS_PATH): $(KERNEL_LIB_OBJS)
-	@mkdir -p $(dir $@)
-	$(AR) $(ARFLAGS) $(KERNEL_LIBS_PATH) $(KERNEL_LIB_OBJS)
-
-  else
-    $(info No optimized kernel available for this architecture: $(TARGET_ARCH))
-  endif
 endif

--- a/tensorflow/lite/experimental/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/helper_functions.inc
@@ -184,11 +184,11 @@ $(1)_LOCAL_HDRS := $(3)
 $(1)_LOCAL_OBJS := $$(addprefix $$(OBJDIR), \
 $$(patsubst %.cc,%.o,$$(patsubst %.c,%.o,$$($(1)_LOCAL_SRCS))))
 $(1)_BINARY := $$(BINDIR)$(1)
-$$($(1)_BINARY): $$($(1)_LOCAL_OBJS) $$(KERNEL_LIBS_PATH) $$(MICROLITE_LIB_PATH)
+$$($(1)_BINARY): $$($(1)_LOCAL_OBJS) $$(MICROLITE_LIB_PATH)
 	@mkdir -p $$(dir $$@)
 	$$(CXX) $$(CXXFLAGS) $$(INCLUDES) \
 	-o $$($(1)_BINARY) $$($(1)_LOCAL_OBJS) \
-	$$(LIBFLAGS) $$(MICROLITE_LIB_PATH) $$(KERNEL_LIBS_PATH) $$(LDFLAGS) $$(MICROLITE_LIBS)
+	$$(LIBFLAGS) $$(MICROLITE_LIB_PATH) $$(LDFLAGS) $$(MICROLITE_LIBS)
 
 $(1): $$($(1)_BINARY)
 $(1)_bin: $$($(1)_BINARY).bin


### PR DESCRIPTION
Thanks for https://github.com/tensorflow/tensorflow/pull/27274 ! I wanted to give detailed feedback on it, and I thought the best approach might be a pull request to your change, so I can show you concretely my suggestions.

First, this is great, thanks again for putting this together, I'm excited to have CMSIS NN kernels making their way into TF Lite. This is an important step, and there's not much documentation available on adding specialized kernel implementations, so I wanted to go through the PR in detail to show what we're thinking of.

We're hoping that the "TAGS" method will be the main way to specify what optimized implementations are requested. The advantage of this is that if a word is included as a tag, then any implementations in subfolders (for example micro/kernels/cmsis-nn/depthwise_conv.cc) will replace the top-level reference versions (micro/kernels/depthwise_conv.cc) automatically.

The original PR used a separate KERNEL_LIB argument to do something similar, but this meant the makefile itself had to do a lot of the work of replacing implementations. I switched over to specifying TAGS="cmsis-nn" instead, like this:

`make -f tensorflow/lite/experimental/micro/tools/make/Makefile TAGS=cmsis-nn TARGET=bluepill test_depthwise_conv_test`

This meant I could remove a lot of the code in cmsis.inc. I did make one other change there too, removing the separate library step, and including the CMSIS NN .c files directly in the MicroLite source list. That removes the need to add library includes elsewhere in the code, but if you have a strong preference towards keeping a separate .a let me know and we can figure out a better approach.

Otherwise this looks awesome, so let me know what you think about this approach, and I'm keen to chat in person when we get a chance.